### PR TITLE
Extend examples, make them easy to copy and paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ import Polysemy.Input
 import Polysemy.Output
 import Polysemy.Error
 import Polysemy.Resource
-import qualified Control.Exception as X
 
 -- Using Teletype effect from above
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,8 @@ Teletype effect:
 
 ```haskell
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE BlockArguments, DataKinds, FlexibleContexts, GADTs, LambdaCase,
-             PolyKinds, RankNTypes, ScopedTypeVariables, TypeApplications,
-             TypeOperators, TypeFamilies, UnicodeSyntax
-#-}
+{-# LANGUAGE LambdaCase, BlockArguments #-}
+{-# LANGUAGE GADTs, FlexibleContexts, TypeOperators, DataKinds, PolyKinds #-}
 
 import Polysemy
 import Polysemy.Input
@@ -85,149 +83,71 @@ runTeletypeIO = interpret $ \case
   ReadTTY      -> sendM getLine
   WriteTTY msg -> sendM $ putStrLn msg
 
-runTeletypeBoring :: [String] -> Sem (Teletype ': r) a -> Sem r ([String], a)
-runTeletypeBoring i
-  = runFoldMapOutput pure
-  . runListInput i
-  . reinterpret2 \case
+runTeletypePure :: [String] -> Sem (Teletype ': r) a -> Sem r ([String], a)
+runTeletypePure i
+  = runFoldMapOutput pure  -- For each WriteTTY in our program, consume an output by appending it to the list in a ([String], a)
+  . runListInput i         -- Treat each element of our list of strings as a line of input
+  . reinterpret2 \case     -- Reinterpret our effect in terms of Input and Output
       ReadTTY -> maybe "" id <$> input
       WriteTTY msg -> output msg
 
--- Continuations so we can build up chains of behavior
-echoK :: Member Teletype r => Sem r () -> Sem r ()
-echoK k = do
-  a <- readTTY
-  when (a == "") $ pure ()
-  when (a /= "") do
-    writeTTY a
-    k
-
-revK :: Member Teletype r => Sem r () -> Sem r ()
-revK k = do
-  a <- readTTY
-  when (a == "") $ pure ()
-  when (a /= "") do
-    writeTTY (reverse a)
-    k
-
--- Fixpoints
 
 echo :: Member Teletype r => Sem r ()
-echo = fix echoK
+echo = do
+  i <- readTTY
+  case i of
+    "" -> pure ()
+    _  -> writeTTY i >> echo
 
-rev :: Member Teletype r => Sem r ()
-rev = fix revK
-
-alternating :: Member Teletype r => Sem r ()
-alternating = fix (echoK . revK)
 
 -- Let's pretend
-echoBoring :: [String] -> Sem '[] ([String], ())
-echoBoring = flip runTeletypeBoring echo
+echoPure :: [String] -> Sem '[] ([String], ())
+echoPure = flip runTeletypePure echo
 
-revBoring :: [String] -> Sem '[] ([String], ())
-revBoring = flip runTeletypeBoring rev
-
-alternatingBoring :: [String] -> Sem '[] ([String], ())
-alternatingBoring = flip runTeletypeBoring alternating
-
-boring :: [String] -> [[String]]
-boring = map (fst . run) . sequence [echoBoring, revBoring, alternatingBoring]
+pureOutput :: [String] -> [String]
+pureOutput = fst . run . echoPure
 
 -- Now let's do things
 echoIO :: Sem '[Lift IO] ()
 echoIO = runTeletypeIO echo
 
-revIO :: Sem '[Lift IO] ()
-revIO = runTeletypeIO rev
-
-alternatingIO :: Sem '[Lift IO] ()
-alternatingIO = runTeletypeIO alternating
-
--- cycle echo and reverse until a blank line
+-- echo forever
 main :: IO ()
-main = runM alternatingIO
+main = runM echoIO
 ```
 
 
 Resource effect:
 
 ```haskell
+{-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE BlockArguments, DataKinds, FlexibleContexts, GADTs, LambdaCase,
-             PolyKinds, RankNTypes, ScopedTypeVariables, TypeApplications,
-             TypeOperators, TypeFamilies, UnicodeSyntax
-#-}
+{-# LANGUAGE LambdaCase, BlockArguments #-}
+{-# LANGUAGE GADTs, FlexibleContexts, TypeOperators, DataKinds, PolyKinds, TypeApplications #-}
 
 import Prelude hiding (throw, catch, bracket)
 import Polysemy
 import Polysemy.Input
 import Polysemy.Output
 import Polysemy.Error
+import Polysemy.Resource
 import qualified Control.Exception as X
 
-data Teletype m a where
-  ReadTTY  :: Teletype m String
-  WriteTTY :: String -> Teletype m ()
-
-data Resource m a where
-  Bracket :: m a -> (a -> m ()) -> (a -> m b) -> Resource m b
-
-makeSem ''Teletype
-makeSem ''Resource
-
-
-runTeletypeIO :: Member (Lift IO) r => Sem (Teletype ': r) a -> Sem r a
-runTeletypeIO = interpret $ \case
-  ReadTTY      -> sendM getLine
-  WriteTTY msg -> sendM $ putStrLn msg
-
-runTeletypeBoring :: [String] -> Sem (Teletype ': r) a -> Sem r ([String], a)
-runTeletypeBoring i
-  = runFoldMapOutput pure
-  . runListInput i
-  . reinterpret2 \case
-      ReadTTY -> maybe "" id <$> input
-      WriteTTY msg -> output msg
-
-
-runResource
-    :: forall r a
-     . Member (Lift IO) r
-    => (∀ x. Sem r x -> IO x)
-    -> Sem (Resource ': r) a
-    -> Sem r a
-runResource finish = interpretH $ \case
-  Bracket alloc dealloc use -> do
-    a <- runT  alloc
-    d <- bindT dealloc
-    u <- bindT use
-
-    let runIt :: Sem (Resource ': r) x -> IO x
-        runIt = finish .@ runResource
-
-    sendM $ X.bracket (runIt a) (runIt . d) (runIt . u)
+-- Using Teletype effect from above
 
 data CustomException = ThisException | ThatException deriving Show
-instance X.Exception CustomException
 
 program :: Members '[Resource, Teletype, Error CustomException] r => Sem r ()
 program = catch work $ \e -> writeTTY ("Caught " ++ show e)
   where work = bracket (readTTY) (const $ writeTTY "exiting bracket") $ \input -> do
           writeTTY "entering bracket"
-          when (input == "explode") $ throw ThisException
-          writeTTY input
-          when (input == "weird stuff") $ throw ThatException
-          writeTTY "no exceptions"
+          case input of
+            "explode"     -> throw ThisException
+            "weird stuff" -> writeTTY input >> throw ThatException
+            _             -> writeTTY input >> writeTTY "no exceptions"
 
-boringProgram :: IO (Either CustomException ([String], ()))
-boringProgram = (runM .@ runResource) . runError @CustomException . runTeletypeBoring ["words"] $ program
-
-boringExplosion :: IO (Either CustomException ([String], ()))
-boringExplosion = (runM .@ runResource) . runError @CustomException . runTeletypeBoring ["explode"] $ program
-
-ioProgram :: IO (Either CustomException ())
-ioProgram = (runM .@ runResource .@@ runErrorInIO @CustomException) . runTeletypeIO $ program
+main :: IO (Either CustomException ())
+main = (runM .@ runResource .@@ runErrorInIO @CustomException) . runTeletypeIO $ program
 ```
 
 Easy.
@@ -290,4 +210,3 @@ You're going to want to stick all of this into your `package.yaml` file.
     - TypeOperators
     - TypeFamilies
 ```
-


### PR DESCRIPTION
For the purpose of getting new users off on the right foot immediately, I added the necessary pragmas to get these working, and built out a trivial example of how to actually use `runConsoleIO`. I wanted to write something like `runConsoleBoring` as an example of mocking using `Input` and `Output` maybe(?), but I wasn't sure how to go about it. I also haven't tried writing a `Resource` example, yet.