### PR TITLE
Redundant typeable

### DIFF
--- a/src/Polysemy/Error.hs
+++ b/src/Polysemy/Error.hs
@@ -34,8 +34,7 @@ makeSem ''Error
 -- | Run an 'Error' effect in the style of
 -- 'Control.Monad.Trans.Except.ExceptT'.
 runError
-    :: Typeable e
-    => Sem (Error e ': r) a
+    :: Sem (Error e ': r) a
     -> Sem r (Either e a)
 runError (Sem m) = Sem $ \k -> E.runExceptT $ m $ \u ->
   case decomp u of
@@ -55,8 +54,7 @@ runError (Sem m) = Sem $ \k -> E.runExceptT $ m $ \u ->
 {-# INLINE runError #-}
 
 runError_b
-    :: Typeable e
-    => Sem (Error e ': r) a
+    :: Sem (Error e ': r) a
     -> Sem r (Either e a)
 runError_b = runError
 {-# NOINLINE runError_b #-}

--- a/src/Polysemy/Input.hs
+++ b/src/Polysemy/Input.hs
@@ -40,8 +40,7 @@ runConstInput c = interpret \case
 -- | Run an 'Input' effect by providing a different element of a list each
 -- time. Returns 'Nothing' after the list is exhausted.
 runListInput
-    :: Typeable i
-    => [i]
+    :: [i]
     -> Sem (Input (Maybe i) ': r) a
     -> Sem r a
 runListInput is = fmap snd . runState is . reinterpret \case

--- a/src/Polysemy/Internal/Combinators.hs
+++ b/src/Polysemy/Internal/Combinators.hs
@@ -21,7 +21,6 @@ module Polysemy.Internal.Combinators
 
 import qualified Control.Monad.Trans.State.Lazy as LS
 import qualified Control.Monad.Trans.State.Strict as S
-import           Data.Typeable
 import           Polysemy.Internal
 import           Polysemy.Internal.CustomErrors
 import           Polysemy.Internal.Effect
@@ -73,8 +72,7 @@ interpretH f (Sem m) = m $ \u ->
 -- | A highly-performant combinator for interpreting an effect statefully. See
 -- 'stateful' for a more user-friendly variety of this function.
 interpretInStateT
-    :: Typeable s
-    => (∀ x m. e m x -> S.StateT s (Sem r) x)
+    :: (∀ x m. e m x -> S.StateT s (Sem r) x)
     -> s
     -> Sem (e ': r) a
     -> Sem r (s, a)
@@ -93,8 +91,7 @@ interpretInStateT f s (Sem m) = Sem $ \k ->
 -- | A highly-performant combinator for interpreting an effect statefully. See
 -- 'stateful' for a more user-friendly variety of this function.
 interpretInLazyStateT
-    :: Typeable s
-    => (∀ x m. e m x -> LS.StateT s (Sem r) x)
+    :: (∀ x m. e m x -> LS.StateT s (Sem r) x)
     -> s
     -> Sem (e ': r) a
     -> Sem r (s, a)
@@ -112,8 +109,7 @@ interpretInLazyStateT f s (Sem m) = Sem $ \k ->
 ------------------------------------------------------------------------------
 -- | Like 'interpret', but with access to an intermediate state @s@.
 stateful
-    :: Typeable s
-    => (∀ x m. e m x -> s -> Sem r (s, x))
+    :: (∀ x m. e m x -> s -> Sem r (s, x))
     -> s
     -> Sem (e ': r) a
     -> Sem r (s, a)
@@ -124,8 +120,7 @@ stateful f = interpretInStateT $ \e -> S.StateT $ fmap swap . f e
 ------------------------------------------------------------------------------
 -- | Like 'interpret', but with access to an intermediate state @s@.
 lazilyStateful
-    :: Typeable s
-    => (∀ x m. e m x -> s -> Sem r (s, x))
+    :: (∀ x m. e m x -> s -> Sem r (s, x))
     -> s
     -> Sem (e ': r) a
     -> Sem r (s, a)
@@ -277,8 +272,7 @@ interpretH_b = interpretH
 
 
 interpretInStateT_b
-    :: Typeable s
-    => (∀ x m. e m x -> S.StateT s (Sem r) x)
+    :: (∀ x m. e m x -> S.StateT s (Sem r) x)
     -> s
     -> Sem (e ': r) a
     -> Sem r (s, a)
@@ -287,8 +281,7 @@ interpretInStateT_b = interpretInStateT
 
 
 interpretInLazyStateT_b
-    :: Typeable s
-    => (∀ x m. e m x -> LS.StateT s (Sem r) x)
+    :: (∀ x m. e m x -> LS.StateT s (Sem r) x)
     -> s
     -> Sem (e ': r) a
     -> Sem r (s, a)

--- a/src/Polysemy/Internal/Effect.hs
+++ b/src/Polysemy/Internal/Effect.hs
@@ -52,7 +52,7 @@ class (∀ m. Functor m => Functor (e m)) => Effect e where
   -- * If instead it is given the intial state, both computations will see the
   -- same state, but the result of (at least) one will necessarily be ignored.
   weave
-      :: (Functor s, Functor m, Functor n, Typeable1 s, Typeable s)
+      :: (Functor s, Functor m, Functor n)
       => s ()
       -> (∀ x. s (m x) -> n (s x))
       -> e m a
@@ -61,8 +61,6 @@ class (∀ m. Functor m => Functor (e m)) => Effect e where
   -- | When @e@ is first order, 'weave' can be given for free.
   default weave
       :: ( Coercible (e m (s a)) (e n (s a))
-         , Typeable1 s
-         , Typeable s
          , Functor s
          , Functor m
          , Functor n

--- a/src/Polysemy/Internal/Effect.hs
+++ b/src/Polysemy/Internal/Effect.hs
@@ -5,11 +5,7 @@ module Polysemy.Internal.Effect where
 
 import Data.Coerce
 import Data.Functor.Identity
-import Data.Kind (Constraint)
-import Data.Typeable
 
-
-type Typeable1 f = (∀ y. Typeable y => Typeable (f y) :: Constraint)
 
 ------------------------------------------------------------------------------
 -- | The class for semantic effects.

--- a/src/Polysemy/Internal/Tactics.hs
+++ b/src/Polysemy/Internal/Tactics.hs
@@ -69,7 +69,7 @@ import Polysemy.Internal.Union
 --
 -- Power users may explicitly use 'getInitialStateT' and 'bindT' to construct
 -- whatever data flow they'd like; although this is usually unnecessary.
-type Tactical e m r x = ∀ f. (Functor f, Typeable1 f)
+type Tactical e m r x = ∀ f. Functor f
                           => Sem (WithTactics e f m r) (f x)
 
 type WithTactics e f m r = Tactics f m (e ': r) ': r
@@ -134,9 +134,7 @@ bindT f = send $ HoistInterpretation f
 -- higher-order ones.
 liftT
     :: forall m f r e a
-     . ( Functor f
-       , Typeable1 f
-       )
+     . Functor f
     => Sem r a
     -> Sem (WithTactics e f m r) (f a)
 liftT m = do

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -52,7 +52,7 @@ data Union (r :: [(* -> *) -> * -> *]) (m :: * -> *) a where
 
 
 data Yo e m a where
-  Yo :: (Functor f, Typeable1 f, Typeable f)
+  Yo :: Functor f
      => e m a
      -> f ()
      -> (forall x. f (m x) -> n (f x))

--- a/src/Polysemy/Output.hs
+++ b/src/Polysemy/Output.hs
@@ -31,7 +31,7 @@ makeSem ''Output
 -- | Run an 'Output' effect by transforming it into a monoid.
 runFoldMapOutput
     :: forall o m r a
-     . (Typeable m, Monoid m)
+     . Monoid m
     => (o -> m)
     -> Sem (Output o ': r) a
     -> Sem r (m, a)
@@ -58,8 +58,7 @@ runIgnoringOutput = interpret \case
 -- @since 0.1.2.0
 runBatchOutput
     :: forall o r a
-     . (Typeable o)
-    => Int
+     . Int
     -> Sem (Output [o] ': r) a
     -> Sem (Output [[o]] ': r) a
 runBatchOutput 0 m = raise $ runIgnoringOutput m

--- a/src/Polysemy/Random.hs
+++ b/src/Polysemy/Random.hs
@@ -31,9 +31,7 @@ makeSem ''Random
 -- | Run a 'Random' effect with an explicit 'R.RandomGen'.
 runRandom
     :: forall q r a
-     . ( Typeable q
-       , R.RandomGen q
-       )
+     . R.RandomGen q
     => q
     -> Sem (Random ': r) a
     -> Sem r (q, a)

--- a/src/Polysemy/State.hs
+++ b/src/Polysemy/State.hs
@@ -50,7 +50,7 @@ modify f = do
 
 ------------------------------------------------------------------------------
 -- | Run a 'State' effect with local state.
-runState :: Typeable s => s -> Sem (State s ': r) a -> Sem r (s, a)
+runState :: s -> Sem (State s ': r) a -> Sem r (s, a)
 runState = stateful $ \case
   Get   -> \s -> pure (s, s)
   Put s -> const $ pure (s, ())
@@ -59,7 +59,7 @@ runState = stateful $ \case
 
 ------------------------------------------------------------------------------
 -- | Run a 'State' effect with local state, lazily.
-runLazyState :: Typeable s => s -> Sem (State s ': r) a -> Sem r (s, a)
+runLazyState :: s -> Sem (State s ': r) a -> Sem r (s, a)
 runLazyState = lazilyStateful $ \case
   Get   -> \s -> pure (s, s)
   Put s -> const $ pure (s, ())

--- a/src/Polysemy/Writer.hs
+++ b/src/Polysemy/Writer.hs
@@ -44,7 +44,7 @@ runOutputAsWriter = interpret \case
 -- | Run a 'Writer' effect in the style of 'Control.Monad.Trans.Writer.WriterT'
 -- (but without the nasty space leak!)
 runWriter
-    :: (Monoid o, Typeable o)
+    :: Monoid o
     => Sem (Writer o ': r) a
     -> Sem r (o, a)
 runWriter = runState mempty . reinterpretH \case


### PR DESCRIPTION
@glaebhoerl [asked](https://twitter.com/glaebhoerl/status/1119606664762658819) what the Typeable constraints were for, I tried to delete a few so that the compiler errors would give me the answer, and was surprised to discover that most of the Typeable constraints are actually redundant!

I recommend adding `-fwarn-redundant-constraints` to your `ghc-options`, it reveals even more redundant constraints.