### PR TITLE
Add Members and (>@>) type synonyms

### DIFF
--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -3,7 +3,6 @@ module Polysemy
     Sem ()
   , Member
   , Members
-  , type (>@>)
 
   -- * Running Sem
   , run

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -2,6 +2,8 @@ module Polysemy
   ( -- * Core Types
     Sem ()
   , Member
+  , Members
+  , type (>@>)
 
   -- * Running Sem
   , run

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -7,7 +7,6 @@ module Polysemy.Internal
   ( Sem (..)
   , Member
   , Members
-  , type (>@>)
   , send
   , sendM
   , run
@@ -154,28 +153,6 @@ newtype Sem r a = Sem
 type family Members es r :: Constraint where
   Members '[]       r = ()
   Members (e ': es) r = (Member e r, Members es r)
-
-
-------------------------------------------------------------------------------
--- | Compact alternative to 'Sem' type with 'Member' effects:
---
--- @
--- foo :: \'['Polysemy.Output.Output' Int, 'Polysemy.Output.Output' Bool] >@> ()
--- @
---
--- translates into:
---
--- @
--- foo :: ( 'Member' ('Polysemy.Output.Output' Int) r
---        , 'Member' ('Polysemy.Output.Output' Bool) r
---        )
---     => 'Sem' r ()
--- @
---
--- (NB: keep in mind that 'r' variable representing list of all effects is
--- hidden behind rank-2 type --- use 'Members' instead if you need access to it.)
-infixr 1 >@>
-type es >@> a = ∀ r. Members r es => Sem r a
 
 
 ------------------------------------------------------------------------------

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -174,7 +174,7 @@ type family Members es r :: Constraint where
 --
 -- (NB: keep in mind that 'r' variable representing list of all effects is
 -- hidden behind rank-2 type --- use 'Members' instead if you need access to it.)
-infix 0 >@>
+infixl 1 >@>
 type es >@> a = ∀ r. Members r es => Sem r a
 
 

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -138,6 +138,7 @@ newtype Sem r a = Sem
 -- @
 -- foo :: 'Members' \'[ 'Polysemy.Output.Output' Int
 --                 , 'Polysemy.Output.Output' Bool
+--                 , 'Polysemy.State' String
 --                 ] r
 --     => 'Sem' r ()
 -- @
@@ -147,6 +148,7 @@ newtype Sem r a = Sem
 -- @
 -- foo :: ( 'Member' ('Polysemy.Output.Output' Int) r
 --        , 'Member' ('Polysemy.Output.Output' Bool) r
+--        , 'Member' ('Polysemy.State' String) r
 --        )
 --     => 'Sem' r ()
 -- @

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -174,7 +174,7 @@ type family Members es r :: Constraint where
 --
 -- (NB: keep in mind that 'r' variable representing list of all effects is
 -- hidden behind rank-2 type --- use 'Members' instead if you need access to it.)
-infixl 1 >@>
+infixr 1 >@>
 type es >@> a = ∀ r. Members r es => Sem r a
 
 

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -153,7 +153,7 @@ newtype Sem r a = Sem
 -- @
 type family Members es r :: Constraint where
   Members '[]       r = ()
-  Members (e ': es) r = (Member e r, Members r es)
+  Members (e ': es) r = (Member e r, Members es r)
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
When having many effects in one function, type signatures tend to get hard to read. I am proposing adding two new type synonyms - `Members`, which takes list of effects instead of one and `(>@>)` (_at-fish_ or whatever you want to call it :smile:), which constructs type from list of member effects and return type:
```haskell
foo :: ( Member (Output Int)  r
       , Member (Output Bool) r
       , Member Console       r
       )
    => Sem r ()
```
could be written simply as:
```haskell
foo :: '[Output Int, Output Bool, Console] >@> ()
```

There are few things I am not completely sure about:
- [x] (https://github.com/isovector/polysemy/pull/24#issuecomment-487040049) Should `Members` be even available, or is `(>@>)` sufficient enough for all purposes?
- [ ] If yes, should `r` in `Members es r` in  appear before list to make constraint more readable on multiple lines?
- [x] (https://github.com/isovector/polysemy/pull/24#issuecomment-487040049) Can rank-2 `r` create some complications in specific cases?
- [x] (https://github.com/isovector/polysemy/pull/24#issuecomment-487040049) What should operator look like? `(>@>)` does not pop up in Stackage search (and I personally like it :smile:). Should it actually be an operator?
- [ ] Should types of both synonyms be restricted somehow?