### PR TITLE
Support versions of GHC without QuantifiedConstraints

### DIFF
--- a/src/Polysemy/Internal/Combinators.hs
+++ b/src/Polysemy/Internal/Combinators.hs
@@ -40,7 +40,7 @@ swap ~(a, b) = (b, a)
 -- | The simplest way to produce an effect handler. Interprets an effect @e@ by
 -- transforming it into other effects inside of @r@.
 interpret
-    :: FirstOrder e m0 "interpret"
+    :: FirstOrder m0 e "interpret"
     => (∀ x m. e m x -> Sem r x)
        -- ^ A natural transformation from the handled effect to other effects
        -- already in 'Sem'.
@@ -154,7 +154,7 @@ reinterpretH f (Sem m) = Sem $ \k -> m $ \u ->
 -- 'Polysemy.State.runState', meaning it's free to 'reinterpret' in terms of
 -- the 'Polysemy.State.State' effect and immediately run it.
 reinterpret
-    :: FirstOrder e1 m0 "reinterpret"
+    :: FirstOrder m0 e1 "reinterpret"
     => (∀ m x. e1 m x -> Sem (e2 ': r) x)
        -- ^ A natural transformation from the handled effect to the new effect.
     -> Sem (e1 ': r) a
@@ -185,7 +185,7 @@ reinterpret2H f (Sem m) = Sem $ \k -> m $ \u ->
 ------------------------------------------------------------------------------
 -- | Like 'reinterpret', but introduces /two/ intermediary effects.
 reinterpret2
-    :: FirstOrder e1 m0 "reinterpret2"
+    :: FirstOrder m0 e1 "reinterpret2"
     => (∀ m x. e1 m x -> Sem (e2 ': e3 ': r) x)
        -- ^ A natural transformation from the handled effect to the new effects.
     -> Sem (e1 ': r) a
@@ -215,7 +215,7 @@ reinterpret3H f (Sem m) = Sem $ \k -> m $ \u ->
 ------------------------------------------------------------------------------
 -- | Like 'reinterpret', but introduces /three/ intermediary effects.
 reinterpret3
-    :: FirstOrder e1 m0 "reinterpret3"
+    :: FirstOrder m0 e1 "reinterpret3"
     => (∀ m x. e1 m x -> Sem (e2 ': e3 ': e4 ': r) x)
        -- ^ A natural transformation from the handled effect to the new effects.
     -> Sem (e1 ': r) a
@@ -230,7 +230,7 @@ reinterpret3 f = reinterpret3H $ \(e :: e m x) -> liftT @m $ f e
 -- intercept other effects and insert logic around them.
 intercept
     :: ( Member e r
-       , FirstOrder e m0 "intercept"
+       , FirstOrder m0 e "intercept"
        )
     => (∀ x m. e m x -> Sem r x)
        -- ^ A natural transformation from the handled effect to other effects

--- a/src/Polysemy/Internal/Combinators.hs
+++ b/src/Polysemy/Internal/Combinators.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE QuantifiedConstraints #-}
 
 {-# OPTIONS_HADDOCK not-home #-}
 
@@ -41,7 +40,7 @@ swap ~(a, b) = (b, a)
 -- | The simplest way to produce an effect handler. Interprets an effect @e@ by
 -- transforming it into other effects inside of @r@.
 interpret
-    :: FirstOrder e "interpret"
+    :: FirstOrder e m0 "interpret"
     => (∀ x m. e m x -> Sem r x)
        -- ^ A natural transformation from the handled effect to other effects
        -- already in 'Sem'.
@@ -155,7 +154,7 @@ reinterpretH f (Sem m) = Sem $ \k -> m $ \u ->
 -- 'Polysemy.State.runState', meaning it's free to 'reinterpret' in terms of
 -- the 'Polysemy.State.State' effect and immediately run it.
 reinterpret
-    :: FirstOrder e1 "reinterpret"
+    :: FirstOrder e1 m0 "reinterpret"
     => (∀ m x. e1 m x -> Sem (e2 ': r) x)
        -- ^ A natural transformation from the handled effect to the new effect.
     -> Sem (e1 ': r) a
@@ -186,7 +185,7 @@ reinterpret2H f (Sem m) = Sem $ \k -> m $ \u ->
 ------------------------------------------------------------------------------
 -- | Like 'reinterpret', but introduces /two/ intermediary effects.
 reinterpret2
-    :: FirstOrder e1 "reinterpret2"
+    :: FirstOrder e1 m0 "reinterpret2"
     => (∀ m x. e1 m x -> Sem (e2 ': e3 ': r) x)
        -- ^ A natural transformation from the handled effect to the new effects.
     -> Sem (e1 ': r) a
@@ -216,7 +215,7 @@ reinterpret3H f (Sem m) = Sem $ \k -> m $ \u ->
 ------------------------------------------------------------------------------
 -- | Like 'reinterpret', but introduces /three/ intermediary effects.
 reinterpret3
-    :: FirstOrder e1 "reinterpret3"
+    :: FirstOrder e1 m0 "reinterpret3"
     => (∀ m x. e1 m x -> Sem (e2 ': e3 ': e4 ': r) x)
        -- ^ A natural transformation from the handled effect to the new effects.
     -> Sem (e1 ': r) a
@@ -231,7 +230,7 @@ reinterpret3 f = reinterpret3H $ \(e :: e m x) -> liftT @m $ f e
 -- intercept other effects and insert logic around them.
 intercept
     :: ( Member e r
-       , FirstOrder e "intercept"
+       , FirstOrder e m0 "intercept"
        )
     => (∀ x m. e m x -> Sem r x)
        -- ^ A natural transformation from the handled effect to other effects

--- a/src/Polysemy/Internal/CustomErrors.hs
+++ b/src/Polysemy/Internal/CustomErrors.hs
@@ -122,7 +122,7 @@ type family FirstOrderError e (fn :: Symbol) :: k where
 --
 -- Note that the parameter 'm' is only required to work around supporting
 -- versions of GHC without QuantifiedConstraints
-type FirstOrder e m fn = Coercible (e m) (e (FirstOrderError e fn))
+type FirstOrder m e fn = Coercible (e m) (e (FirstOrderError e fn))
 
 
 ------------------------------------------------------------------------------

--- a/src/Polysemy/Internal/CustomErrors.hs
+++ b/src/Polysemy/Internal/CustomErrors.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes   #-}
 {-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
@@ -120,7 +119,10 @@ type family FirstOrderError e (fn :: Symbol) :: k where
 ------------------------------------------------------------------------------
 -- | This constraint gives helpful error messages if you attempt to use a
 -- first-order combinator with a higher-order type.
-type FirstOrder e fn = ∀ m. Coercible (e m) (e (FirstOrderError e fn))
+--
+-- Note that the parameter 'm' is only required to work around supporting
+-- versions of GHC without QuantifiedConstraints
+type FirstOrder e m fn = Coercible (e m) (e (FirstOrderError e fn))
 
 
 ------------------------------------------------------------------------------

--- a/src/Polysemy/Internal/Effect.hs
+++ b/src/Polysemy/Internal/Effect.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DefaultSignatures     #-}
-{-# LANGUAGE QuantifiedConstraints #-}
 
 {-# OPTIONS_HADDOCK not-home #-}
 

--- a/src/Polysemy/Internal/Tactics.hs
+++ b/src/Polysemy/Internal/Tactics.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE QuantifiedConstraints #-}
 
 {-# OPTIONS_HADDOCK not-home #-}
 

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -80,14 +80,8 @@ liftYo e = Yo e (Identity ()) (fmap Identity . runIdentity) runIdentity
 {-# INLINE liftYo #-}
 
 
-instance (Functor m) => Functor (Union r m) where
+instance Functor (Union r m) where
   fmap f (Union w t) = Union w $ fmap' f t
-    where
-      -- This is necessary to delay the interaction between the type family
-      -- 'IndexOf' and the quantified superclass constraint on 'Effect'.
-      fmap' :: (Functor m, Effect f) => (a -> b) -> f m a -> f m b
-      fmap' = fmap
-      {-# INLINE fmap' #-}
   {-# INLINE fmap #-}
 
 

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}


### PR DESCRIPTION
Addresses #29 by implementing the [workaround used by `fused-effects`](https://github.com/fused-effects/fused-effects/blob/4d0e056c95e4016d6c8d8e14909702874e17863a/src/Control/Effect/Carrier.hs#L16) that @patrickt suggested.