### PR TITLE
Removes BlockArguments (pre-GHC 8.6 compat)

### DIFF
--- a/bench/Poly.hs
+++ b/bench/Poly.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments   #-}
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs            #-}
@@ -57,7 +56,9 @@ runConsoleBoring :: [String] -> Semantic (Console ': r) a -> Semantic r ([String
 runConsoleBoring inputs
   = runFoldMapOutput (:[])
   . runListInput inputs
-  . reinterpret2 \case
+  . reinterpret2
+  (\case
       ReadLine -> maybe "" id <$> input
       WriteLine msg -> output msg
+  )
 

--- a/polysemy-plugin/test/PluginSpec.hs
+++ b/polysemy-plugin/test/PluginSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes        #-}
-{-# LANGUAGE BlockArguments             #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 
@@ -35,9 +34,8 @@ oStrState = put "hello"
 err :: Member (Error e) r => Sem r Bool
 err =
   catch
-    do
-      throw undefined
-    \_ -> pure True
+    (throw undefined)
+    (\_ -> pure True)
 
 
 errState :: Num s => Members '[Error e, State s] r => Sem r Bool

--- a/src/Polysemy/Input.hs
+++ b/src/Polysemy/Input.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments  #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Polysemy.Input
@@ -31,8 +30,10 @@ makeSem ''Input
 ------------------------------------------------------------------------------
 -- | Run an 'Input' effect by always giving back the same value.
 runConstInput :: i -> Sem (Input i ': r) a -> Sem r a
-runConstInput c = interpret \case
-  Input -> pure c
+runConstInput c = interpret
+  (\case
+      Input -> pure c
+  )
 {-# INLINE runConstInput #-}
 
 
@@ -43,18 +44,22 @@ runListInput
     :: [i]
     -> Sem (Input (Maybe i) ': r) a
     -> Sem r a
-runListInput is = fmap snd . runState is . reinterpret \case
-  Input -> do
-    s <- gets uncons
-    for_ s $ put . snd
-    pure $ fmap fst s
+runListInput is = fmap snd . runState is . reinterpret
+  (\case
+      Input -> do
+        s <- gets uncons
+        for_ s $ put . snd
+        pure $ fmap fst s
+  )
 {-# INLINE runListInput #-}
 
 
 ------------------------------------------------------------------------------
 -- | Runs an 'Input' effect by evaluating a monadic action for each request.
 runMonadicInput :: Sem r i -> Sem (Input i ': r) a -> Sem r a
-runMonadicInput m = interpret \case
-  Input -> m
+runMonadicInput m = interpret
+  (\case
+      Input -> m
+  )
 {-# INLINE runMonadicInput #-}
 

--- a/src/Polysemy/Internal/TH/Performance.hs
+++ b/src/Polysemy/Internal/TH/Performance.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments  #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_HADDOCK not-home #-}

--- a/src/Polysemy/Output.hs
+++ b/src/Polysemy/Output.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments  #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Polysemy.Output
@@ -35,16 +34,20 @@ runFoldMapOutput
     => (o -> m)
     -> Sem (Output o ': r) a
     -> Sem r (m, a)
-runFoldMapOutput f = runState mempty . reinterpret \case
-  Output o -> modify (<> f o)
+runFoldMapOutput f = runState mempty . reinterpret
+  (\case
+      Output o -> modify (<> f o)
+  )
 {-# INLINE runFoldMapOutput #-}
 
 
 ------------------------------------------------------------------------------
 -- | Run an 'Output' effect by ignoring it.
 runIgnoringOutput :: Sem (Output o ': r) a -> Sem r a
-runIgnoringOutput = interpret \case
-  Output _ -> pure ()
+runIgnoringOutput = interpret
+  (\case
+      Output _ -> pure ()
+  )
 {-# INLINE runIgnoringOutput #-}
 
 

--- a/src/Polysemy/Random.hs
+++ b/src/Polysemy/Random.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments  #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Polysemy.Random
@@ -35,15 +34,17 @@ runRandom
     => q
     -> Sem (Random ': r) a
     -> Sem r (q, a)
-runRandom q = runState q . reinterpret \case
-  Random -> do
-    ~(a, q') <- gets @q R.random
-    put q'
-    pure a
-  RandomR r -> do
-    ~(a, q') <- gets @q $ R.randomR r
-    put q'
-    pure a
+runRandom q = runState q . reinterpret
+  (\case
+      Random -> do
+        ~(a, q') <- gets @q R.random
+        put q'
+        pure a
+      RandomR r -> do
+        ~(a, q') <- gets @q $ R.randomR r
+        put q'
+        pure a
+  )
 {-# INLINE runRandom #-}
 
 

--- a/src/Polysemy/Writer.hs
+++ b/src/Polysemy/Writer.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments  #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections   #-}
 
@@ -35,8 +34,10 @@ makeSem ''Writer
 ------------------------------------------------------------------------------
 -- | Transform an 'Output' effect into a 'Writer' effect.
 runOutputAsWriter :: Member (Writer o) r => Sem (Output o ': r) a -> Sem r a
-runOutputAsWriter = interpret \case
-  Output o -> tell o
+runOutputAsWriter = interpret
+  (\case
+      Output o -> tell o
+  )
 {-# INLINE runOutputAsWriter #-}
 
 
@@ -47,17 +48,19 @@ runWriter
     :: Monoid o
     => Sem (Writer o ': r) a
     -> Sem r (o, a)
-runWriter = runState mempty . reinterpretH \case
-  Tell o -> do
-    modify (<> o) >>= pureT
-  Listen m -> do
-    mm <- runT m
-    -- TODO(sandy): this is fucking stupid
-    (o, fa) <- raise $ runWriter mm
-    pure $ fmap (o, ) fa
-  Censor f m -> do
-    mm <- runT m
-    ~(o, a) <- raise $ runWriter mm
-    modify (<> f o)
-    pure a
+runWriter = runState mempty . reinterpretH
+  (\case
+      Tell o -> do
+        modify (<> o) >>= pureT
+      Listen m -> do
+        mm <- runT m
+        -- TODO(sandy): this is fucking stupid
+        (o, fa) <- raise $ runWriter mm
+        pure $ fmap (o, ) fa
+      Censor f m -> do
+        mm <- runT m
+        ~(o, a) <- raise $ runWriter mm
+        modify (<> f o)
+        pure a
+  )
 

--- a/test/FusionSpec.hs
+++ b/test/FusionSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments   #-}
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE TemplateHaskell  #-}
 {-# LANGUAGE TypeApplications #-}
@@ -60,11 +59,10 @@ go = do
 
 
 tryIt :: Either Bool String
-tryIt = run . runError @Bool $ do
+tryIt = run . runError @Bool $
   catch @Bool
-    do
-      throw False
-    \_ -> pure "hello"
+    (throw False)
+    (\_ -> pure "hello")
 
 
 countDown :: Int -> Int


### PR DESCRIPTION
Travis was failing on versions of GHC pre-8.6 because of the `BlockArguments` language extension.

Removing it makes the code inarguably less cool to read, but it should be fix the compatibility issue so maybe that's okay.