### PR TITLE
Automatically inline recursive calls in the plugin

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,3 +28,10 @@
 
 ## Unreleased changes
 
+- **NEEDS MAJOR REVISION**: no longer require `inlineRecursiveCalls` --- the
+    plugin does it automatically when compiling with `-O2`
+- Deprecated `inlineRecursiveCalls`; slated for removal in the next version
+- **NEEDS MAJOR PLUGIN REVISION**: plugin now automatically inlines recursive
+    calls
+
+

--- a/polysemy-plugin/package.yaml
+++ b/polysemy-plugin/package.yaml
@@ -20,6 +20,8 @@ dependencies:
 - ghc >= 8.6.3 && < 8.7
 - ghc-tcplugins-extra >= 0.3 && < 0.4
 - polysemy >= 0.1
+- syb >= 0.7 && <0.8
+- transformers >= 0.5.5.0 && < 0.6
 
 library:
   source-dirs: src

--- a/polysemy-plugin/package.yaml
+++ b/polysemy-plugin/package.yaml
@@ -35,10 +35,12 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     - -fplugin=Polysemy.Plugin
+    - -O2
     dependencies:
     - polysemy-plugin
     - hspec >= 2.6.0 && < 3
     - should-not-typecheck >= 2.1.0 && < 3
+    - inspection-testing >= 0.4.1.1 && < 0.5
 
 default-extensions:
   - DataKinds

--- a/polysemy-plugin/src/Polysemy/Plugin.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin.hs
@@ -97,7 +97,8 @@ installTodos todos = do
   dflags <- getDynFlags
 
   case optLevel dflags of
-    2 -> do
+    0 -> pure todos
+    _ -> do
       mods <- moduleSetElts <$> getVisibleOrphanMods
       pure $ case any ((== polysemyInternal) . moduleName) mods of
         True  -> CoreDoPluginPass "Inline Recursive Calls" inlineRecursiveCalls
@@ -106,6 +107,5 @@ installTodos todos = do
               ++ extraPhases dflags
 #endif
         False -> todos
-    _ -> pure todos
 
 

--- a/polysemy-plugin/src/Polysemy/Plugin/InlineRecursiveCalls.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/InlineRecursiveCalls.hs
@@ -1,0 +1,89 @@
+module Polysemy.Plugin.InlineRecursiveCalls
+  ( inlineRecursiveCalls
+  ) where
+
+import BasicTypes
+import Control.Monad
+import Control.Monad.Trans.State
+import CoreMonad
+import CoreSyn
+import Data.Monoid
+import Data.Traversable
+import GHC
+import Generics.SYB
+import HscTypes
+import IdInfo
+import Name
+import SrcLoc
+import UniqSupply
+import Unique
+import Var
+
+
+inlineRecursiveCalls :: ModGuts -> CoreM ModGuts
+inlineRecursiveCalls mg = do
+  uniqSupply <- liftIO $ mkSplitUniqSupply '\x264a'
+  flip evalStateT uniqSupply $ do
+    bs <- traverse loopbreakBinds $ mg_binds mg
+    pure $ mg { mg_binds = bs }
+
+
+type CoreSupplyM = StateT UniqSupply CoreM
+
+
+getUniq :: CoreSupplyM Unique
+getUniq = do
+  (u, s) <- gets takeUniqFromSupply
+  put s
+  pure u
+
+
+containsName :: CoreBndr -> CoreExpr -> Bool
+containsName n e =
+  getAny $
+    everything
+      (<>)
+      (mkQ (Any False) $ matches n)
+      e
+
+
+matches :: CoreBndr -> CoreExpr -> Any
+matches n (Var n') | n == n' = Any True
+matches _ _ = Any False
+
+
+replace :: Id -> Id -> Expr CoreBndr -> Expr CoreBndr
+replace n n' = everywhere $ mkT go
+  where
+    go :: Expr CoreBndr -> Expr CoreBndr
+    go v@(Var nn)
+      | nn == n   = Var n'
+      | otherwise = v
+    go x = x
+
+
+loopbreaker :: CoreBndr -> CoreExpr -> CoreSupplyM [(Var, CoreExpr)]
+loopbreaker n b = do
+  u <- getUniq
+  let info' = setInlinePragInfo (idInfo n) alwaysInlinePragma
+      n' = mkLocalVar
+             (idDetails n)
+             (mkInternalName u (occName n) noSrcSpan)
+             (idType n)
+         $ setInlinePragInfo vanillaIdInfo neverInlinePragma
+  pure [ (lazySetIdInfo n info', replace n n' b)
+       , (n', Var n)
+       ]
+
+
+loopbreakBinds
+    :: Bind CoreBndr
+    -> CoreSupplyM (Bind CoreBndr)
+loopbreakBinds nr@(NonRec n b)
+  | containsName n b = Rec <$> loopbreaker n b
+  | otherwise        = pure nr
+loopbreakBinds (Rec bs) = fmap (Rec . join) . for bs $ \(n, b) ->
+  case containsName n b of
+    False -> pure [(n, b)]
+    True  -> loopbreaker n b
+

--- a/polysemy-plugin/src/Polysemy/Plugin/InlineRecursiveCalls.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/InlineRecursiveCalls.hs
@@ -77,6 +77,8 @@ loopbreaker n b = do
        ]
 
 
+-- TODO(sandy): Make this only break loops in functions whose type ends in `Sem
+-- * * -> Sem * *` for wildcards `*`
 loopbreakBinds
     :: Bind CoreBndr
     -> CoreSupplyM (Bind CoreBndr)

--- a/polysemy-plugin/src/Polysemy/Plugin/InlineRecursiveCalls.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/InlineRecursiveCalls.hs
@@ -65,7 +65,8 @@ replace n n' = everywhere $ mkT go
 loopbreaker :: CoreBndr -> CoreExpr -> CoreSupplyM [(Var, CoreExpr)]
 loopbreaker n b = do
   u <- getUniq
-  let info' = setInlinePragInfo (idInfo n) alwaysInlinePragma
+  let Just info = zapUsageInfo $ idInfo n
+      info' = setInlinePragInfo info alwaysInlinePragma
       n' = mkLocalVar
              (idDetails n)
              (mkInternalName u (occName n) noSrcSpan)

--- a/polysemy-plugin/src/Polysemy/Plugin/Phases.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Phases.hs
@@ -1,0 +1,59 @@
+module Polysemy.Plugin.Phases
+  ( extraPhases
+  ) where
+
+import BasicTypes
+import CoreMonad
+import DynFlags
+
+extraPhases :: DynFlags -> [CoreToDo]
+extraPhases dflags =
+    [ CoreDoSpecialising
+    , simpl_phase 0 ["post-late-spec"] max_iter
+    , simpl_gently
+    , CoreDoStaticArgs
+    , CoreDoSpecialising
+    -- TODO(sandy): probably don't need this one
+    , simpl_phase 0 ["post-late-spec"] max_iter
+    , simpl_phases
+    , simpl_gently
+    ]
+
+  where
+    option   = flip gopt dflags
+    max_iter = maxSimplIterations dflags
+    rules_on = option Opt_DoLambdaEtaExpansion
+    phases   = simplPhases dflags
+
+    base_mode = SimplMode
+      { sm_phase      = error "base_mode"
+      , sm_names      = []
+      , sm_dflags     = dflags
+      , sm_rules      = option Opt_EnableRewriteRules
+      , sm_eta_expand = rules_on
+      , sm_inline     = True
+      , sm_case_case  = True
+      }
+
+    simpl_phase phase names iter = CoreDoPasses
+      [ runWhen (phase `elem` strictnessBefore dflags) CoreDoStrictness
+      , CoreDoSimplify iter $
+          base_mode { sm_phase = Phase phase
+                    , sm_names = names
+                    }
+      , runMaybe (ruleCheck dflags) $ CoreDoRuleCheck $ Phase phase
+      ]
+
+    simpl_gently = CoreDoSimplify max_iter $ base_mode
+      { sm_phase = InitialPhase
+      , sm_names = ["Gentle"]
+      , sm_rules = rules_on
+      , sm_inline = True
+      , sm_case_case = False
+      }
+
+    simpl_phases = CoreDoPasses
+      [ simpl_phase phase ["main"] max_iter
+      | phase <- [phases, phases-1 .. 1]
+      ]
+

--- a/polysemy-plugin/test/InlineRecursiveCallsSpec.hs
+++ b/polysemy-plugin/test/InlineRecursiveCallsSpec.hs
@@ -18,7 +18,10 @@ import           Test.Inspection
 spec :: Spec
 spec = describe "inlining recursive calls" $ do
   it "should explicitly break recursion" $ do
-    shouldSucceed $(inspectTest $ 'recursive === 'mutual)
+    -- TODO(sandy): This should use (===) instead of (==-), but can't due to
+    -- a bug in inspection-testing. See:
+    -- https://github.com/nomeata/inspection-testing/pull/19
+    shouldSucceed $(inspectTest $ 'recursive ==- 'mutual)
 
 
 isSuccess :: Result -> Bool

--- a/polysemy-plugin/test/InlineRecursiveCallsSpec.hs
+++ b/polysemy-plugin/test/InlineRecursiveCallsSpec.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -ddump-simpl -dsuppress-coercions -dsuppress-uniques -dsuppress-idinfo #-}
+
+
+module InlineRecursiveCallsSpec
+  ( spec
+  ) where
+
+import qualified Control.Monad.Trans.State as S
+import           Data.Tuple
+import           Polysemy.Internal
+import           Polysemy.Internal.Effect
+import           Polysemy.Internal.Union
+import           Test.Hspec
+import           Test.Inspection
+
+
+spec :: Spec
+spec = describe "inlining recursive calls" $ do
+  it "should explicitly break recursion" $ do
+    shouldSucceed $(inspectTest $ 'recursive === 'mutual)
+
+
+isSuccess :: Result -> Bool
+isSuccess (Success _) = True
+isSuccess (Failure e) = error e
+
+
+shouldSucceed :: Result -> Expectation
+shouldSucceed r = r `shouldSatisfy` isSuccess
+
+
+------------------------------------------------------------------------------
+recursive
+    :: (∀ x m. e m x -> S.StateT s (Sem r) x)
+    -> s
+    -> Sem (e ': r) a
+    -> Sem r (s, a)
+recursive f s (Sem m) = Sem $ \k ->
+  fmap swap $ flip S.runStateT s $ m $ \u ->
+    case decomp u of
+        Left x -> S.StateT $ \s' ->
+          k . fmap swap
+            . weave (s', ()) (uncurry $ recursive f)
+            $ x
+        Right (Yo e z _ y) ->
+          fmap (y . (<$ z)) $ S.mapStateT (usingSem k) $ f e
+
+
+------------------------------------------------------------------------------
+mutual
+    :: (∀ x m. e m x -> S.StateT s (Sem r) x)
+    -> s
+    -> Sem (e ': r) a
+    -> Sem r (s, a)
+mutual f s (Sem m) = Sem $ \k ->
+  fmap swap $ flip S.runStateT s $ m $ \u ->
+    case decomp u of
+        Left x -> S.StateT $ \s' ->
+          k . fmap swap
+            . weave (s', ()) (uncurry $ mutual2 f)
+            $ x
+        Right (Yo e z _ y) ->
+          fmap (y . (<$ z)) $ S.mapStateT (usingSem k) $ f e
+{-# INLINE mutual #-}
+
+mutual2
+    :: (∀ x m. e m x -> S.StateT s (Sem r) x)
+    -> s
+    -> Sem (e ': r) a
+    -> Sem r (s, a)
+mutual2 = mutual
+{-# NOINLINE mutual2 #-}
+

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -88,9 +88,6 @@ module Polysemy
   , reinterpret2H
   , reinterpret3H
 
-    -- * Improving Performance for Interpreters
-  , inlineRecursiveCalls
-
     -- * Composing IO-based Interpreters
   , (.@)
   , (.@@)
@@ -119,6 +116,7 @@ module Polysemy
   , runSemantic
   , makeSemantic
   , makeSemantic_
+  , inlineRecursiveCalls
   ) where
 
 import Polysemy.Internal

--- a/src/Polysemy/Internal/TH/Performance.hs
+++ b/src/Polysemy/Internal/TH/Performance.hs
@@ -1,86 +1,15 @@
-{-# LANGUAGE BlockArguments  #-}
-{-# LANGUAGE TemplateHaskell #-}
-
 {-# OPTIONS_HADDOCK not-home #-}
 
 module Polysemy.Internal.TH.Performance
   ( inlineRecursiveCalls
   ) where
 
-import Control.Monad
-import Data.Bool
-import Data.Maybe (maybeToList, mapMaybe)
-import Data.Monoid (Any (..))
-import Generics.SYB
 import Language.Haskell.TH
 
-------------------------------------------------------------------------------
--- | GHC has a really hard time inlining recursive calls---such as those used in
--- interpreters for higher-order effects. This can have disastrous repercussions
--- for your performance.
---
--- Fortunately there's a solution, but it's ugly boilerplate. You can enable
--- @-XTemplateHaskell@ and use 'inlineRecursiveCalls' to convince GHC to make
--- these functions fast again.
---
--- @
--- 'inlineRecursiveCalls' [d|
---   'Polysemy.Reader.runReader' :: i -> 'Polysemy.Sem' ('Polysemy.Reader.Reader' i ': r) a -> 'Polysemy.Sem' r a
---   'Polysemy.Reader.runReader' i = 'Polysemy.interpretH' $ \\case
---     'Polysemy.Reader.Ask' -> 'Polysemy.pureT' i
---     'Polysemy.Reader.Local' f m -> do
---       mm <- 'Polysemy.runT' m
---       'Polysemy.raise' $ 'Polysemy.Reader.runReader' (f i) mm
---   |]
--- @
+{-# DEPRECATED inlineRecursiveCalls
+      "Enabling polysemy-plugin now automatically inlines recursive calls"
+      #-}
+
 inlineRecursiveCalls :: Q [Dec] -> Q [Dec]
-inlineRecursiveCalls m = do
-  decs <- m
-  let types   = mapMaybe getType decs
-      inlines = mapMaybe hasInline decs
-  fmap join $ traverse (loopbreaker types inlines) decs
-
-
-isRecursive :: Name -> [Clause] -> Bool
-isRecursive n cs =
-  getAny $
-    everything
-      (<>)
-      (mkQ (Any False) $ withRec (const $ Any False) (Any True) n)
-      cs
-
-
-withRec :: (Exp -> a) -> a -> Name -> Exp -> a
-withRec unmatched matched n = \case
-  VarE n' | n == n' -> matched
-  a                 -> unmatched a
-
-
-getType :: Dec -> Maybe (Name, Type)
-getType (SigD n t) = Just (n, t)
-getType _ = Nothing
-
-
-hasInline :: Dec -> Maybe (Name)
-hasInline (PragmaD (InlineP n Inline _ _)) = Just n
-hasInline _ = Nothing
-
-
-loopbreaker :: [(Name, Type)] -> [Name] -> Dec -> Q [Dec]
-loopbreaker types inlined (FunD n cs)
-  | isRecursive n cs = do
-      nLB <- newName $ mconcat
-               [ "___"
-               , nameBase n
-               , "___loop_breaker"
-               ]
-      pure $
-        [ FunD n $ everywhere (mkT $ withRec id (VarE nLB) n) cs
-        , FunD nLB [Clause [] (NormalB $ VarE n) []]
-        , PragmaD $ InlineP nLB NoInline FunLike AllPhases
-        ] ++ maybeToList (fmap (SigD nLB) $ lookup n types)
-          ++ bool [PragmaD $ InlineP n Inline FunLike AllPhases]
-                  []
-                  (elem n inlined)
-loopbreaker _ _ z = pure [z]
+inlineRecursiveCalls = id
 


### PR DESCRIPTION
Previously there was a TH method `inlineRecursiveCalls` that would break self-recursion into mutual-recursion and add some janky inlining properties to convince the inliner to simplify things.

The TH was unpleasant, in that it would prevent people from writing haddock for their interpreters --- and that it was a thing people needed to think about in the first place.

This PR adds a CoreToDo pass to make the same transformation directly in the core representation. It also adds the additional optimization passes necessary to get GHC to inline interpreters away.