### PR TITLE
Remove erroneous Prelude import

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Resource effect:
 {-# LANGUAGE LambdaCase, BlockArguments #-}
 {-# LANGUAGE GADTs, FlexibleContexts, TypeOperators, DataKinds, PolyKinds, TypeApplications #-}
 
-import Prelude hiding (throw, catch, bracket)
 import Polysemy
 import Polysemy.Input
 import Polysemy.Output


### PR DESCRIPTION
I left that in when writing the README example because I use a custom Prelude. Whoops.