### PR TITLE
Fixes #54

### DIFF
--- a/polysemy-plugin/test/InlineRecursiveCallsSpec.hs
+++ b/polysemy-plugin/test/InlineRecursiveCallsSpec.hs
@@ -18,10 +18,7 @@ import           Test.Inspection
 spec :: Spec
 spec = describe "inlining recursive calls" $ do
   it "should explicitly break recursion" $ do
-    -- TODO(sandy): This should use (===) instead of (==-), but can't due to
-    -- a bug in inspection-testing. See:
-    -- https://github.com/nomeata/inspection-testing/pull/19
-    shouldSucceed $(inspectTest $ 'recursive ==- 'mutual)
+    shouldSucceed $(inspectTest $ 'recursive === 'mutual)
 
 
 isSuccess :: Result -> Bool

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,5 +9,4 @@ extra-deps:
 - monadLib-3.9
 - ghc-lib-0.20190204
 - th-abstraction-0.3.1.0
-- git: https://github.com/nomeata/inspection-testing.git
-  commit: 764025131052b4bbfb99d9a209350f1d99c7a5cb
+- inspection-testing-0.4.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,3 +9,5 @@ extra-deps:
 - monadLib-3.9
 - ghc-lib-0.20190204
 - th-abstraction-0.3.1.0
+- git: https://github.com/nomeata/inspection-testing.git
+  commit: 764025131052b4bbfb99d9a209350f1d99c7a5cb


### PR DESCRIPTION
This can be landed against `inspection-testing-0.4.1.3` as soon as https://github.com/nomeata/inspection-testing/pull/34 lands in a proper release.