### PR TITLE
Update polysemy-plugin version bound

### DIFF
--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -68,7 +68,7 @@ test-suite polysemy-plugin-test
     , ghc-tcplugins-extra >=0.3 && <0.4
     , hspec >=2.6.0 && <3
     , inspection-testing >=0.4.1.1 && <0.5
-    , polysemy >=0.1
+    , polysemy >=0.3
     , polysemy-plugin
     , should-not-typecheck >=2.1.0 && <3
     , syb >=0.7 && <0.8


### PR DESCRIPTION
The test suite is made for 0.3 and doesn't compile with earlier versions due to Yo now taking another argument since https://github.com/isovector/polysemy/pull/71