### PR TITLE
Ensure wanted constraints are emitted only once.

### DIFF
--- a/polysemy-plugin/package.yaml
+++ b/polysemy-plugin/package.yaml
@@ -22,6 +22,7 @@ dependencies:
 - polysemy >= 0.1
 - syb >= 0.7 && <0.8
 - transformers >= 0.5.5.0 && < 0.6
+- containers >= 0.6 && <= 0.7
 
 library:
   source-dirs: src
@@ -41,7 +42,7 @@ tests:
     - polysemy-plugin
     - hspec >= 2.6.0 && < 3
     - should-not-typecheck >= 2.1.0 && < 3
-    - inspection-testing >= 0.4.1.1 && < 0.5
+    - inspection-testing >= 0.4.2 && < 0.5
 
 default-extensions:
   - DataKinds

--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aceeac8482d66cadbcf9559c89ab7ff683f188490a14d0701c2a56b73fcd9b95
+-- hash: a515749ff182fca310bc1890e96ce0b182b3596261ba5db4661be3c44717f4c7
 
 name:           polysemy-plugin
 version:        0.2.0.2
@@ -40,6 +40,7 @@ library
   default-extensions: DataKinds DeriveFunctor FlexibleContexts GADTs LambdaCase PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TypeApplications TypeOperators TypeFamilies UnicodeSyntax
   build-depends:
       base >=4.7 && <5
+    , containers >=0.6 && <=0.7
     , ghc >=8.6.3 && <8.7
     , ghc-tcplugins-extra >=0.3 && <0.4
     , polysemy >=0.1
@@ -64,10 +65,11 @@ test-suite polysemy-plugin-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -fplugin=Polysemy.Plugin -O2
   build-depends:
       base >=4.7 && <5
+    , containers >=0.6 && <=0.7
     , ghc >=8.6.3 && <8.7
     , ghc-tcplugins-extra >=0.3 && <0.4
     , hspec >=2.6.0 && <3
-    , inspection-testing >=0.4.1.1 && <0.5
+    , inspection-testing >=0.4.2 && <0.5
     , polysemy >=0.3
     , polysemy-plugin
     , should-not-typecheck >=2.1.0 && <3

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -118,6 +118,13 @@ countLength eq as =
    in zipWith (curry $ bimap head length) grouped grouped
 
 
+------------------------------------------------------------------------------
+-- | 'Ct's don't have an 'Ord' or 'Hashable' or anything useful for comparing
+-- for equality. So instead we put cheat by pretty-printing the constraint, and
+-- using _that_ as our unique key. It's gross, but it works. Using 'FastString'
+-- here gives us O(1) comparisons.
+--
+-- Use 'hashWanted' to get one of these.
 newtype HashedCt = HashedCt
   { getHashedCt :: FastString
   }

--- a/polysemy-plugin/test/BadSpec.hs
+++ b/polysemy-plugin/test/BadSpec.hs
@@ -5,6 +5,7 @@
 module BadSpec where
 
 import Polysemy
+import Polysemy.State
 import Test.Hspec
 import Test.ShouldNotTypecheck
 
@@ -21,6 +22,9 @@ negativePos :: Member (KVStore String v) r => Sem r (Maybe Bool)
 negativePos = do
   getKV "hello"
 
+badState :: Member (State a) r => Sem r ()
+badState = put ()
+
 
 spec :: Spec
 spec = do
@@ -29,4 +33,6 @@ spec = do
       shouldNotTypecheck positivePos
     it "should not typecheck in negative position" $ do
       shouldNotTypecheck negativePos
+    it "should not typecheck badly polymorphic State" $ do
+      shouldNotTypecheck badState
 


### PR DESCRIPTION
This is a fix for the "solveSimpleWanteds: too many iterations" problem
that people are running into. In these cases, the plugin is being asked
to solve the same `Member` constraint several times, and generating
a new wanted each time. In doing so, GHC thinks that work was done, so
it will ask the plugin to run again next time. This process diverges,
and produces the error.

Fixes #79