### PR TITLE
Allow bidirectional typechecking in the plugin

### DIFF
--- a/polysemy-plugin/test/PluginSpec.hs
+++ b/polysemy-plugin/test/PluginSpec.hs
@@ -132,9 +132,8 @@ spec = do
       flipShouldBe (Right @Bool (10 :: Float, True))  . run $ runError $ runState 0 errState
 
   describe "Output effect" $ do
-    it "should unify recursively" $ do
-      -- TODO(sandy): This should unify even without the type app. Bug #95
-      flipShouldBe 11 . sum @[] . fst . run . runFoldMapOutput id $ do
+    it "should unify recursively with tyvars" $ do
+      flipShouldBe 11 . sum . fst . run . runFoldMapOutput id $ do
         output [1]
         output $ replicate 2 5
 


### PR DESCRIPTION
The plugin used to choke on this:

```haskell
flipShouldBe 11 . sum . fst . run . runFoldMapOutput id $ do
  output [1]
  output $ replicate 2 5
```

because it would fail to unify `Output (t Int)` (the polymorphic `Traversable` variable in `sum`) with `Output [Int]`.

In this case, there are no given constraints, so the plugin is attempting to solve a `Member (Output (t Int)) '[Output [Int]]`. We reuse the codepath for unifying wanted/givens, pretending like the
`Output (t Int)` is a given.[^1]

[^1]: Pretending it's a wanted breaks the common case of trying to call, eg. `runState (5 :: Num a => a)`  on an effect `State Int`.

So now we have a "wanted" `Output [Int]`, and a "given" `Output (t Int)`. In general, this thing isn't OK to solve. Consider a real example:

```haskell
foo :: Member (Output (t Int)) r => Sem r ()
foo = output [5]
```

This is a type error, because the polymorphism goes the wrong way. We have no guarantees that `t` is supposed to be `[]`.

But in our original example, this isn't a problem, because our `t` isn't actually in given position. It's just an artifact of reusing the code! `mkWanted` now takes a new parameter for whether or not it's OK to allow
the givens to be polymorphic.

Such a thing necessitates a change though. We never want to unify a polymorphic *effect* in given position. Doing so will break Haskell's regular type inference that determines what the effect row should be, based on the order in which the interpreters are run.

Fixes #95