### PR TITLE
Don't emit the FirstOrder error for unknown effects

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ dependencies:
 - template-haskell >= 2.14.0.0 && <2.15
 - th-abstraction >= 0.3 && <= 0.4
 - transformers >= 0.5.5.0 && < 0.6
+- first-class-families >= 0.5.0.0 && < 0.6
 
 default-extensions:
   - DataKinds

--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b0c2017df2b347cf23d719d6420a5635f1d14bc71a5f8d12babc9ba302444323
+-- hash: a6d973da5703808ae7d4cfe9848c4403e9aa0f9f2d47dfdba64a80d761b4e4fb
 
 name:           polysemy
 version:        0.4.0.0
@@ -70,6 +70,7 @@ library
   build-depends:
       base >=4.7 && <5
     , containers >=0.6 && <=0.7
+    , first-class-families >=0.5.0.0 && <0.6
     , mtl >=2.2.2 && <3
     , syb >=0.7 && <=0.8
     , template-haskell >=2.14.0.0 && <2.15
@@ -107,6 +108,7 @@ test-suite polysemy-test
       base >=4.7 && <5
     , containers >=0.6 && <=0.7
     , doctest >=0.16.0.1 && <0.17
+    , first-class-families >=0.5.0.0 && <0.6
     , hspec >=2.6.0 && <3
     , inspection-testing >=0.4.1.1 && <0.5
     , mtl >=2.2.2 && <3
@@ -130,6 +132,7 @@ benchmark polysemy-bench
       base >=4.7 && <5
     , containers >=0.6 && <=0.7
     , criterion
+    , first-class-families >=0.5.0.0 && <0.6
     , free
     , freer-simple
     , mtl

--- a/src/Polysemy/Internal/CustomErrors.hs
+++ b/src/Polysemy/Internal/CustomErrors.hs
@@ -39,9 +39,6 @@ type family IfStuck (tyvar :: k) (b :: k1) (c :: Exp k1) :: k1 where
   IfStuck T1 b c = b
   IfStuck a  b c = Eval c
 
-type WhenStuck (tyvar :: k) (b :: Constraint) =
-  IfStuck tyvar b (Pure (() :: Constraint))
-
 
 type AmbigousEffectMessage r e t vs =
         ( 'Text "Ambiguous use of effect '"

--- a/src/Polysemy/Internal/CustomErrors.hs
+++ b/src/Polysemy/Internal/CustomErrors.hs
@@ -16,6 +16,7 @@ module Polysemy.Internal.CustomErrors
 
 import Data.Coerce
 import Data.Kind
+import Fcf
 import GHC.TypeLits
 
 
@@ -26,7 +27,6 @@ type family DefiningModuleForEffect (e :: k) :: Symbol where
   DefiningModuleForEffect e     = DefiningModule e
 
 
-
 data T1 m a
 
 type family Break (c :: Constraint)
@@ -34,6 +34,13 @@ type family Break (c :: Constraint)
   Break _ T1 = ((), ())
   Break _ c  = ()
 
+
+type family IfStuck (tyvar :: k) (b :: k1) (c :: Exp k1) :: k1 where
+  IfStuck T1 b c = b
+  IfStuck a  b c = Eval c
+
+type WhenStuck (tyvar :: k) (b :: Constraint) =
+  IfStuck tyvar b (Pure (() :: Constraint))
 
 
 type AmbigousEffectMessage r e t vs =
@@ -123,7 +130,14 @@ type family FirstOrderError e (fn :: Symbol) :: k where
 --
 -- Note that the parameter 'm' is only required to work around supporting
 -- versions of GHC without QuantifiedConstraints
-type FirstOrder m e fn = Coercible (e m) (e (FirstOrderError e fn))
+type FirstOrder m e fn = IfStuck e (() :: Constraint) (FirstOrderFcf m e fn)
+
+data FirstOrderFcf
+    :: (Type -> Type)
+    -> ((Type -> Type) -> Type -> Type)
+    -> Symbol
+    -> Exp Constraint
+type instance Eval (FirstOrderFcf m e fn) = Coercible (e m) (e (FirstOrderError e fn))
 
 
 ------------------------------------------------------------------------------

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,11 +5,12 @@ packages:
 - polysemy-plugin
 
 extra-deps:
-- dump-core-0.1.3.2
-- monadLib-3.9
-- ghc-lib-0.20190204
-- th-abstraction-0.3.1.0
-- inspection-testing-0.4.2
-- bifunctors-5.5.4
 - aeson-1.4.3.0
+- bifunctors-5.5.4
+- dump-core-0.1.3.2
+- first-class-families-0.5.0.0
+- ghc-lib-0.20190204
+- inspection-testing-0.4.2
+- monadLib-3.9
+- th-abstraction-0.3.1.0
 

--- a/test/DoctestSpec.hs
+++ b/test/DoctestSpec.hs
@@ -75,16 +75,9 @@ interpretBadFirstOrder = ()
 --   Output o -> modify (<> f o)
 -- :}
 -- ...
--- ... 'e10' is higher-order, but 'reinterpret' can help only
--- ... with first-order effects.
+-- ... Probable cause: ...reinterpret... is applied to too few arguments
 -- ...
---
--- PROBLEM: Output _is_ first order! But we're not inferring `e1 ~ Output`,
--- because the real type error breaks inference. So instead we get `e10`, which
--- we can't prove is first order, so we emit the error.
---
--- SOLUTION: Don't emit the error when `e1` is a tyvar.
-firstOrderReinterpret'WRONG = ()
+tooFewArgumentsReinterpret = ()
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR introduces the FCF machinery that will give us more control over writing type-level functions. It defines an `IfStuck a b c` tyfam that will leave `b` around if `a` is stuck, otherwise it will fcf-evaluate `c`. Everything is polykinded so we can stack these things together to make big logic chains to emit specific variables depending on what exactly is stuck.

Fixes #106