### PR TITLE
Trying to fix some Travis stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ stack.yaml.lock
 core-html/
 *~
 *.prof
+.ghc.environment.*
+dist-newstyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ matrix:
   include:
     - ghc: "8.6.5"
     - ghc: "8.4.4"
-    - ghc: "8.2.2"
+#     - ghc: "8.2.2"
+# Disabling GHC 8.2.2 as polysemy-plugin tests do not pass
 
 install:
  - cabal --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cabal: "2.4"
 
 matrix:
   include:
-    - ghc: "8.6.3"
+    - ghc: "8.6.5"
     - ghc: "8.4.4"
     - ghc: "8.2.2"
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: . polysemy-plugin
+
+jobs: $ncpus
+
+package *
+  ghc-options: +RTS -A128m -n2m -RTS

--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,7 @@ dependencies:
 - syb >= 0.7 && < 0.8
 - template-haskell >= 2.12.0.0 && < 3
 - th-abstraction >= 0.3.1.0 && < 0.4
-- transformers >= 0.5.5.0 && < 0.6
+- transformers >= 0.5.2.0 && < 0.6
 - first-class-families >= 0.5.0.0 && < 0.6
 
 default-extensions:

--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5d0a33182763e86e1219252267e0912a645a0c8f05094e8f1bbf6f01944a050b
+-- hash: 3968d98882a4dcd7c29fbf7005a12a0ebb333221ed52bb0b815ad025eed394ad
 
 name:           polysemy
 version:        0.4.0.0
@@ -76,7 +76,7 @@ library
     , syb >=0.7 && <0.8
     , template-haskell >=2.12.0.0 && <3
     , th-abstraction >=0.3.1.0 && <0.4
-    , transformers >=0.5.5.0 && <0.6
+    , transformers >=0.5.2.0 && <0.6
   if impl(ghc < 8.6)
     default-extensions: MonadFailDesugaring TypeInType
   if flag(dump-core)
@@ -123,7 +123,7 @@ test-suite polysemy-test
     , syb >=0.7 && <0.8
     , template-haskell >=2.12.0.0 && <3
     , th-abstraction >=0.3.1.0 && <0.4
-    , transformers >=0.5.5.0 && <0.6
+    , transformers >=0.5.2.0 && <0.6
   if impl(ghc < 8.6)
     default-extensions: MonadFailDesugaring TypeInType
   default-language: Haskell2010
@@ -149,7 +149,7 @@ benchmark polysemy-bench
     , syb >=0.7 && <0.8
     , template-haskell >=2.12.0.0 && <3
     , th-abstraction >=0.3.1.0 && <0.4
-    , transformers >=0.5.5.0 && <0.6
+    , transformers >=0.5.2.0 && <0.6
   if impl(ghc < 8.6)
     default-extensions: MonadFailDesugaring TypeInType
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.0
+resolver: lts-13.25
 
 packages:
 - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.25
+resolver: lts-13.0
 
 packages:
 - .


### PR DESCRIPTION
Changes:
- add `cabal.project` to let `cabal v2-*` commands know about `polysemy-plugin`
  - also provides some nice `ghc-options` that should speed up compilation (just slightly)
- drops `transformers` lower bound to `0.5.2.0` (which is what it looks like GHC 8.2.2 ships with)
- adds `.ghc.environment` and `dist-newstyle` files to the `.gitignore` since the new `cabal` makes these files and they're annoying
- bumps `stack` LTS to 13.25 to pull in GHC 8.6.5 since that's the latest version of the GHC 8.6 release train
  - bumps GHC version in the Travis test matrix

---

Running `cabal v2-build` works for both `polysemy` and `polysemy-plugin` for GHC 8.2.2 -> GHC 8.6.5, but running `cabal v2-test polysemy-plugin` fails for GHC 8.2.2 with the following error:

<details><summary>Error Log Snippet</summary>
<p>

```
test/PluginSpec.hs:20:8: error:
    • Ambiguous use of effect 'State'
      Possible fix:
        add (Member (State s0) r) to the context of 
          the type signature
      If you already have the constraint you want, instead
        add a type application to specify
          's0' directly, or activate polysemy-plugin which
            can usually infer the type correctly.
    • In a stmt of a 'do' block: s <- get
      In the expression:
        do s <- get
           put s
      In an equation for ‘idState’:
          idState
            = do s <- get
                 put s
   |
20 |   s <- get
   |        ^^^

[... more of the same ...]
```
</p>
</details>